### PR TITLE
docs(audiobooks): Add info about Opus support for audiobooks

### DIFF
--- a/docs/email-setup.md
+++ b/docs/email-setup.md
@@ -183,4 +183,4 @@ Use these settings when creating the provider:
 - All email provider and recipient changes are recorded in the [Audit Log](tools/audit-logs.md).
 - The connection type is auto-detected: port 465 uses SSL, port 587 with StartTLS uses STARTTLS, otherwise plain SMTP.
 - Email sending happens asynchronously. You'll see a toast notification when the send completes or fails.
-- Supported formats for sending: EPUB, PDF, CBX (CBZ/CBR/CB7), MOBI, AZW3, FB2, and Audiobook (M4B/M4A/MP3).
+- Supported formats for sending: EPUB, PDF, CBX (CBZ/CBR/CB7), MOBI, AZW3, FB2, and Audiobook (M4B/M4A/MP3/Opus).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ Click **"Add a Library"** from the dashboard to open the library creation dialog
 | Format Priority | Drag to reorder which format is treated as primary when a book exists in multiple formats |
 | Allowed Formats | Restrict which file formats this library will scan |
 
-Booklore supports EPUB, PDF, MOBI, AZW3, FB2, CBZ/CBR/CB7, M4B, M4A, and MP3.
+Booklore supports EPUB, PDF, MOBI, AZW3, FB2, CBZ/CBR/CB7, M4B, M4A, MP3 and Opus.
 
 After saving, the library scans your folders automatically. See [Setup First Library](library/setup-first-library.md) for a full walkthrough, and [Folder Structure](library/folder-structure.md) for how to organize your files.
 
@@ -105,7 +105,7 @@ Click any book cover, then click **"Read"** to open the built-in reader. Booklor
 | Ebook Reader | EPUB, MOBI, AZW3, FB2 | Bookmarks, annotations, highlights, search, custom fonts, progress sync |
 | PDF Reader | PDF | Page-level progress sync, zoom, page spread modes, annotations |
 | Comic Reader | CBZ, CBR, CB7 | Fit/scroll modes, reading direction (LTR/RTL), slideshow, bookmarks |
-| Audiobook Player | M4B, MP3 | Chapters, track listing, playback speed, progress sync |
+| Audiobook Player | M4B, MP3, Opus | Chapters, track listing, playback speed, progress sync |
 
 ### 📲 E-Readers and Mobile Apps
 

--- a/docs/library/setup-first-library.md
+++ b/docs/library/setup-first-library.md
@@ -55,7 +55,7 @@ Make sure Docker has read access to the selected paths. If folders aren't showin
 
 **Format Priority** sets which file format is treated as primary when a book exists in multiple formats. Drag the chips to reorder.
 
-**Allowed Formats** restricts which file types this library scans. All formats are allowed by default: EPUB, PDF, CBX (CBZ/CBR/CB7), MOBI, AZW3, FB2, and Audiobook (M4B/M4A/MP3).
+**Allowed Formats** restricts which file types this library scans. All formats are allowed by default: EPUB, PDF, CBX (CBZ/CBR/CB7), MOBI, AZW3, FB2, and Audiobook (M4B/M4A/MP3/Opus).
 
 ---
 

--- a/docs/readers/audiobook-player.md
+++ b/docs/readers/audiobook-player.md
@@ -1,6 +1,6 @@
 # 🎧 Audiobook Player
 
-BookLore includes a dedicated audiobook player for M4B, M4A, and MP3 files. It supports chapter navigation, playback speed control, sleep timers, bookmarks, and automatic progress tracking.
+BookLore includes a dedicated audiobook player for M4B, M4A, MP3 and Opus files. It supports chapter navigation, playback speed control, sleep timers, bookmarks, and automatic progress tracking.
 
 ---
 


### PR DESCRIPTION
Added information about the upcoming support for Opus audiobooks as proposed in [the BookLore PR](https://github.com/booklore-app/booklore/pull/3011) (still a draft). Should this be considered a draft as well, until I make the main PR ready for review? Or how do you usually process these PR:s for docs?